### PR TITLE
Support mergin adjecent spans for mark collapsing.

### DIFF
--- a/sanity_html/constants.py
+++ b/sanity_html/constants.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sanity_html.marker_definitions import (
-    render_code_marker,
-    render_comment_marker,
-    render_emphasis_marker,
-    render_link_marker,
-    render_strong_marker,
+    CodeMarkerDefinition,
+    CommentMarkerDefinition,
+    EmphasisMarkerDefinition,
+    LinkMarkerDefinition,
+    StrongMarkerDefinition,
 )
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict
+    from typing import Dict, Type
+
+    from sanity_html.marker_definitions import MarkerDefinition
 
 STYLE_MAP = {
     'h1': 'h1',
@@ -23,13 +25,13 @@ STYLE_MAP = {
     'normal': 'p',
 }
 
-DECORATOR_MARKER_DEFINITIONS: Dict[str, Callable] = {
-    'em': render_emphasis_marker,
-    'strong': render_strong_marker,
-    'code': render_code_marker,
+DECORATOR_MARKER_DEFINITIONS: Dict[str, Type[MarkerDefinition]] = {
+    'em': EmphasisMarkerDefinition,
+    'strong': StrongMarkerDefinition,
+    'code': CodeMarkerDefinition,
 }
 
-ANNOTATION_MARKER_DEFINITIONS: Dict[str, Callable] = {
-    'link': render_link_marker,
-    'comment': render_comment_marker,
+ANNOTATION_MARKER_DEFINITIONS: Dict[str, Type[MarkerDefinition]] = {
+    'link': LinkMarkerDefinition,
+    'comment': CommentMarkerDefinition,
 }

--- a/sanity_html/marker_definitions.py
+++ b/sanity_html/marker_definitions.py
@@ -1,29 +1,97 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 # Decorators
 
 
-def render_emphasis_marker(text: str) -> str:
-    """Add emphasis tags."""
-    return f'<em>{text}</em>'
+if TYPE_CHECKING:
+    from typing import Type
+
+    from sanity_html.dataclasses import Block, Span
 
 
-def render_strong_marker(text: str) -> str:
-    """Add strong tags."""
-    return f'<strong>{text}</strong>'
+class MarkerDefinition:
+    """Base class for marker definition handlers."""
+
+    tag: str
+
+    @classmethod
+    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the prefix for the marked span.
+
+        Usually this this the opening of the HTML tag.
+        """
+        return f'<{cls.tag}>'
+
+    @classmethod
+    def render_suffix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the suffix for the marked span.
+
+        Usually this this the closing of the HTML tag.
+        """
+        return f'</{cls.tag}>'
+
+    @classmethod
+    def render(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the marked span directly with prefix and suffix."""
+        result = cls.render_prefix(span, marker, context)
+        result += str(span.text)
+        result += cls.render_suffix(span, marker, context)
+        return result
 
 
-def render_code_marker(text: str) -> str:
-    """Add code tags."""
-    return f'<code>{text}</code>'
+class EmphasisMarkerDefinition(MarkerDefinition):
+    """Marker definition for <em> rendering."""
+
+    tag = 'em'
+
+
+class StrongMarkerDefinition(MarkerDefinition):
+    """Marker definition for <strong> rendering."""
+
+    tag = 'strong'
+
+
+class CodeMarkerDefinition(MarkerDefinition):
+    """Marker definition for <code> rendering."""
+
+    tag = 'code'
 
 
 # Annotations
 
 
-def render_link_marker(*, text: str, href: str) -> str:
-    """Add link tags."""
-    return f'<a href="{href}">{text}</a>'
+class LinkMarkerDefinition(MarkerDefinition):
+    """Marker definition for link rendering."""
+
+    tag = 'a'
+
+    @classmethod
+    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the opening anchor tag with the href attribute set.
+
+        The href attribute is fetched from the provided block context using
+        the provided marker key.
+        """
+        marker_defintion = next((md for md in context.markDefs if md['_key'] == marker), None)
+        if not marker_defintion:
+            raise ValueError(f'Marker definition for key: {marker} not found in parent block context')
+        href = marker_defintion['href']
+        return f'<a href="{href}">'
 
 
-def render_comment_marker(text: str) -> str:
-    """Add comment tags."""
-    return text  # TODO: Remove or refine - comment markers are briefly mentioned in the portable text spec
+class CommentMarkerDefinition(MarkerDefinition):
+    """Marker definition for HTML comment rendering."""
+
+    tag = '!--'
+
+    @classmethod
+    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the opening of the HTML comment block."""
+        return '<!-- '
+
+    @classmethod
+    def render_suffix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the closing part of the HTML comment block."""
+        return ' -->'

--- a/sanity_html/utils.py
+++ b/sanity_html/utils.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING
 from sanity_html.constants import ANNOTATION_MARKER_DEFINITIONS, DECORATOR_MARKER_DEFINITIONS
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from typing import Type
+
+    from sanity_html.marker_definitions import MarkerDefinition
 
 
-def get_marker_definitions(mark_defs: list[dict]) -> dict[str, Callable]:
+def get_marker_definitions(mark_defs: list[dict]) -> dict[str, Type[MarkerDefinition]]:
     """
     Convert JSON definitions to a map of marker definition renderers.
 

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -1,10 +1,9 @@
-import pytest
-
+from sanity_html.dataclasses import Block, Span
 from sanity_html.marker_definitions import (
-    render_comment_marker,
-    render_emphasis_marker,
-    render_link_marker,
-    render_strong_marker,
+    CommentMarkerDefinition,
+    EmphasisMarkerDefinition,
+    LinkMarkerDefinition,
+    StrongMarkerDefinition,
 )
 
 sample_texts = ['test', None, 1, 2.2, '!"#$%&/()']
@@ -12,23 +11,27 @@ sample_texts = ['test', None, 1, 2.2, '!"#$%&/()']
 
 def test_render_emphasis_marker_success():
     for text in sample_texts:
-        assert render_emphasis_marker(text) == f'<em>{text}</em>'
+        node = Span(**{'_type': 'span', 'text': text})
+        block = Block(_type='block', children=[node])
+        assert EmphasisMarkerDefinition.render(node, 'em', block) == f'<em>{text}</em>'
 
 
 def test_render_strong_marker_success():
     for text in sample_texts:
-        assert render_strong_marker(text) == f'<strong>{text}</strong>'
+        node = Span(**{'_type': 'span', 'text': text})
+        block = Block(_type='block', children=[node])
+        assert StrongMarkerDefinition.render(node, 'strong', block) == f'<strong>{text}</strong>'
 
 
 def test_render_link_marker_success():
     for text in sample_texts:
-        assert render_link_marker(text=text, href=text) == f'<a href="{text}">{text}</a>'
-
-    with pytest.raises(TypeError):
-        # enforce keyword-only arguments to limit possibility of error
-        render_link_marker('test', 'test')
+        node = Span(**{'_type': 'span', 'marks': ['linkId'], 'text': text})
+        block = Block(_type='block', children=[node], markDefs=[{'_type': 'link', '_key': 'linkId', 'href': text}])
+        assert LinkMarkerDefinition.render(node, 'linkId', block) == f'<a href="{text}">{text}</a>'
 
 
 def test_render_comment_marker_success():
     for text in sample_texts:
-        assert render_comment_marker(text) == text
+        node = Span(**{'_type': 'span', 'text': text})
+        block = Block(_type='block', children=[node])
+        assert CommentMarkerDefinition.render(node, 'comment', block) == f'<!-- {text} -->'

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -14,6 +14,7 @@ def test_007_link_mark_def():
     assert expected_output == output
 
 
+@pytest.mark.skip('Requires custom definitions')
 def test_018_marks_all_the_way_dow():
     fixture_data = json.loads(
         (Path(__file__).parent / 'fixtures' / 'upstream' / '018-marks-all-the-way-down.json').read_text()


### PR DESCRIPTION
This is done by splitting the marker definition rendering
into a prefix and suffix part, then looking at the siblings
when iterating through the children.