### PR TITLE
Add decorator markers

### DIFF
--- a/sanity_html/constants.py
+++ b/sanity_html/constants.py
@@ -24,6 +24,7 @@ STYLE_MAP = {
     'h4': 'h4',
     'h5': 'h5',
     'h6': 'h6',
+    'blockquote': 'blockquote',
     'normal': 'p',
 }
 

--- a/sanity_html/constants.py
+++ b/sanity_html/constants.py
@@ -7,7 +7,9 @@ from sanity_html.marker_definitions import (
     CommentMarkerDefinition,
     EmphasisMarkerDefinition,
     LinkMarkerDefinition,
+    StrikeThroughMarkerDefinition,
     StrongMarkerDefinition,
+    UnderlineMarkerDefinition,
 )
 
 if TYPE_CHECKING:
@@ -29,6 +31,8 @@ DECORATOR_MARKER_DEFINITIONS: Dict[str, Type[MarkerDefinition]] = {
     'em': EmphasisMarkerDefinition,
     'strong': StrongMarkerDefinition,
     'code': CodeMarkerDefinition,
+    'underline': UnderlineMarkerDefinition,
+    'strike-through': StrikeThroughMarkerDefinition,
 }
 
 ANNOTATION_MARKER_DEFINITIONS: Dict[str, Type[MarkerDefinition]] = {

--- a/sanity_html/marker_definitions.py
+++ b/sanity_html/marker_definitions.py
@@ -59,6 +59,18 @@ class CodeMarkerDefinition(MarkerDefinition):
     tag = 'code'
 
 
+class UnderlineMarkerDefinition(MarkerDefinition):
+    """Marker definition for <u> rendering."""
+
+    tag = 'u'
+
+
+class StrikeThroughMarkerDefinition(MarkerDefinition):
+    """Marker definition for <strike> rendering."""
+
+    tag = 'strike'
+
+
 # Annotations
 
 

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -3,7 +3,9 @@ from sanity_html.marker_definitions import (
     CommentMarkerDefinition,
     EmphasisMarkerDefinition,
     LinkMarkerDefinition,
+    StrikeThroughMarkerDefinition,
     StrongMarkerDefinition,
+    UnderlineMarkerDefinition,
 )
 
 sample_texts = ['test', None, 1, 2.2, '!"#$%&/()']
@@ -11,27 +13,43 @@ sample_texts = ['test', None, 1, 2.2, '!"#$%&/()']
 
 def test_render_emphasis_marker_success():
     for text in sample_texts:
-        node = Span(**{'_type': 'span', 'text': text})
-        block = Block(_type='block', children=[node])
+        node = Span(_type='span', text=text)
+        block = Block(_type='block', children=[node.__dict__])
         assert EmphasisMarkerDefinition.render(node, 'em', block) == f'<em>{text}</em>'
 
 
 def test_render_strong_marker_success():
     for text in sample_texts:
-        node = Span(**{'_type': 'span', 'text': text})
-        block = Block(_type='block', children=[node])
+        node = Span(_type='span', text=text)
+        block = Block(_type='block', children=[node.__dict__])
         assert StrongMarkerDefinition.render(node, 'strong', block) == f'<strong>{text}</strong>'
+
+
+def test_render_underline_marker_success():
+    for text in sample_texts:
+        node = Span(_type='span', text=text)
+        block = Block(_type='block', children=[node.__dict__])
+        assert UnderlineMarkerDefinition.render(node, 'u', block) == f'<u>{text}</u>'
+
+
+def test_render_strikethrough_marker_success():
+    for text in sample_texts:
+        node = Span(_type='span', text=text)
+        block = Block(_type='block', children=[node.__dict__])
+        assert StrikeThroughMarkerDefinition.render(node, 'strike', block) == f'<strike>{text}</strike>'
 
 
 def test_render_link_marker_success():
     for text in sample_texts:
-        node = Span(**{'_type': 'span', 'marks': ['linkId'], 'text': text})
-        block = Block(_type='block', children=[node], markDefs=[{'_type': 'link', '_key': 'linkId', 'href': text}])
+        node = Span(_type='span', marks=['linkId'], text=text)
+        block = Block(
+            _type='block', children=[node.__dict__], markDefs=[{'_type': 'link', '_key': 'linkId', 'href': text}]
+        )
         assert LinkMarkerDefinition.render(node, 'linkId', block) == f'<a href="{text}">{text}</a>'
 
 
 def test_render_comment_marker_success():
     for text in sample_texts:
-        node = Span(**{'_type': 'span', 'text': text})
-        block = Block(_type='block', children=[node])
+        node = Span(_type='span', text=text)
+        block = Block(_type='block', children=[node.__dict__])
         assert CommentMarkerDefinition.render(node, 'comment', block) == f'<!-- {text} -->'

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -6,13 +6,13 @@ import pytest
 from sanity_html import render
 
 
-def get_text(rel_path) -> dict:
+def get_fixture(rel_path) -> dict:
     """Load and return fixture data as dict."""
     return json.loads((Path(__file__).parent / rel_path).read_text())
 
 
 def test_001_empty_block():
-    fixture_data = get_text('fixtures/upstream/001-empty-block.json')
+    fixture_data = get_fixture('fixtures/upstream/001-empty-block.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -20,7 +20,7 @@ def test_001_empty_block():
 
 
 def test_002_single_spa():
-    fixture_data = get_text('fixtures/upstream/002-single-span.json')
+    fixture_data = get_fixture('fixtures/upstream/002-single-span.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -28,7 +28,7 @@ def test_002_single_spa():
 
 
 def test_003_multiple_spa():
-    fixture_data = get_text('fixtures/upstream/003-multiple-spans.json')
+    fixture_data = get_fixture('fixtures/upstream/003-multiple-spans.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -36,7 +36,7 @@ def test_003_multiple_spa():
 
 
 def test_004_basic_mark_single_spa():
-    fixture_data = get_text('fixtures/upstream/004-basic-mark-single-span.json')
+    fixture_data = get_fixture('fixtures/upstream/004-basic-mark-single-span.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -44,7 +44,7 @@ def test_004_basic_mark_single_spa():
 
 
 def test_005_basic_mark_multiple_adjacent_spa():
-    fixture_data = get_text('fixtures/upstream/005-basic-mark-multiple-adjacent-spans.json')
+    fixture_data = get_fixture('fixtures/upstream/005-basic-mark-multiple-adjacent-spans.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -52,7 +52,7 @@ def test_005_basic_mark_multiple_adjacent_spa():
 
 
 def test_006_basic_mark_nested_mark():
-    fixture_data = get_text('fixtures/upstream/006-basic-mark-nested-marks.json')
+    fixture_data = get_fixture('fixtures/upstream/006-basic-mark-nested-marks.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -60,7 +60,7 @@ def test_006_basic_mark_nested_mark():
 
 
 def test_007_link_mark_def():
-    fixture_data = get_text('fixtures/upstream/007-link-mark-def.json')
+    fixture_data = get_fixture('fixtures/upstream/007-link-mark-def.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -68,7 +68,7 @@ def test_007_link_mark_def():
 
 
 def test_008_plain_header_block():
-    fixture_data = get_text('fixtures/upstream/008-plain-header-block.json')
+    fixture_data = get_fixture('fixtures/upstream/008-plain-header-block.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -79,7 +79,7 @@ def test_008_plain_header_block():
 # expected: <strong><em>app</strong> or website</a></em>.</blockquote>
 # output:   <em><strong>app</strong> or website</em></a>.</blockquote>
 def test_009_messy_link_text():
-    fixture_data = get_text('fixtures/upstream/009-messy-link-text.json')
+    fixture_data = get_fixture('fixtures/upstream/009-messy-link-text.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -87,7 +87,7 @@ def test_009_messy_link_text():
 
 
 def test_010_basic_bullet_list():
-    fixture_data = get_text('fixtures/upstream/010-basic-bullet-list.json')
+    fixture_data = get_fixture('fixtures/upstream/010-basic-bullet-list.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -95,7 +95,7 @@ def test_010_basic_bullet_list():
 
 
 def test_011_basic_numbered_list():
-    fixture_data = get_text('fixtures/upstream/011-basic-numbered-list.json')
+    fixture_data = get_fixture('fixtures/upstream/011-basic-numbered-list.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -103,7 +103,7 @@ def test_011_basic_numbered_list():
 
 
 def test_012_image_support():
-    fixture_data = get_text('fixtures/upstream/012-image-support.json')
+    fixture_data = get_fixture('fixtures/upstream/012-image-support.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -111,7 +111,7 @@ def test_012_image_support():
 
 
 def test_013_materialized_image_support():
-    fixture_data = get_text('fixtures/upstream/013-materialized-image-support.json')
+    fixture_data = get_fixture('fixtures/upstream/013-materialized-image-support.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -119,7 +119,7 @@ def test_013_materialized_image_support():
 
 
 def test_014_nested_list():
-    fixture_data = get_text('fixtures/upstream/014-nested-lists.json')
+    fixture_data = get_fixture('fixtures/upstream/014-nested-lists.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -127,7 +127,7 @@ def test_014_nested_list():
 
 
 def test_015_all_basic_mark():
-    fixture_data = get_text('fixtures/upstream/015-all-basic-marks.json')
+    fixture_data = get_fixture('fixtures/upstream/015-all-basic-marks.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -135,7 +135,7 @@ def test_015_all_basic_mark():
 
 
 def test_016_deep_weird_list():
-    fixture_data = get_text('fixtures/upstream/016-deep-weird-lists.json')
+    fixture_data = get_fixture('fixtures/upstream/016-deep-weird-lists.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -143,7 +143,7 @@ def test_016_deep_weird_list():
 
 
 def test_017_all_default_block_style():
-    fixture_data = get_text('fixtures/upstream/017-all-default-block-styles.json')
+    fixture_data = get_fixture('fixtures/upstream/017-all-default-block-styles.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -152,7 +152,7 @@ def test_017_all_default_block_style():
 
 @pytest.mark.skip('Requires custom definitions')
 def test_018_marks_all_the_way_dow():
-    fixture_data = get_text('fixtures/upstream/018-marks-all-the-way-down.json')
+    fixture_data = get_fixture('fixtures/upstream/018-marks-all-the-way-down.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -160,7 +160,7 @@ def test_018_marks_all_the_way_dow():
 
 
 def test_019_keyle():
-    fixture_data = get_text('fixtures/upstream/019-keyless.json')
+    fixture_data = get_fixture('fixtures/upstream/019-keyless.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -168,7 +168,7 @@ def test_019_keyle():
 
 
 def test_020_empty_array():
-    fixture_data = get_text('fixtures/upstream/020-empty-array.json')
+    fixture_data = get_fixture('fixtures/upstream/020-empty-array.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -176,7 +176,7 @@ def test_020_empty_array():
 
 
 def test_021_list_without_level():
-    fixture_data = get_text('fixtures/upstream/021-list-without-level.json')
+    fixture_data = get_fixture('fixtures/upstream/021-list-without-level.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -184,7 +184,7 @@ def test_021_list_without_level():
 
 
 def test_022_inline_node():
-    fixture_data = get_text('fixtures/upstream/022-inline-nodes.json')
+    fixture_data = get_fixture('fixtures/upstream/022-inline-nodes.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -192,7 +192,7 @@ def test_022_inline_node():
 
 
 def test_023_hard_break():
-    fixture_data = get_text('fixtures/upstream/023-hard-breaks.json')
+    fixture_data = get_fixture('fixtures/upstream/023-hard-breaks.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -200,7 +200,7 @@ def test_023_hard_break():
 
 
 def test_024_inline_image():
-    fixture_data = get_text('fixtures/upstream/024-inline-images.json')
+    fixture_data = get_fixture('fixtures/upstream/024-inline-images.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -208,7 +208,7 @@ def test_024_inline_image():
 
 
 def test_025_image_with_hotspot():
-    fixture_data = get_text('fixtures/upstream/025-image-with-hotspot.json')
+    fixture_data = get_fixture('fixtures/upstream/025-image-with-hotspot.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -216,7 +216,7 @@ def test_025_image_with_hotspot():
 
 
 def test_026_inline_block_with_text():
-    fixture_data = get_text('fixtures/upstream/026-inline-block-with-text.json')
+    fixture_data = get_fixture('fixtures/upstream/026-inline-block-with-text.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -224,7 +224,7 @@ def test_026_inline_block_with_text():
 
 
 def test_027_styled_list_item():
-    fixture_data = get_text('fixtures/upstream/027-styled-list-items.json')
+    fixture_data = get_fixture('fixtures/upstream/027-styled-list-items.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -232,7 +232,7 @@ def test_027_styled_list_item():
 
 
 def test_050_custom_block_type():
-    fixture_data = get_text('fixtures/upstream/050-custom-block-type.json')
+    fixture_data = get_fixture('fixtures/upstream/050-custom-block-type.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -240,7 +240,7 @@ def test_050_custom_block_type():
 
 
 def test_051_override_default():
-    fixture_data = get_text('fixtures/upstream/051-override-defaults.json')
+    fixture_data = get_fixture('fixtures/upstream/051-override-defaults.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -248,7 +248,7 @@ def test_051_override_default():
 
 
 def test_052_custom_mark():
-    fixture_data = get_text('fixtures/upstream/052-custom-marks.json')
+    fixture_data = get_fixture('fixtures/upstream/052-custom-marks.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -256,7 +256,7 @@ def test_052_custom_mark():
 
 
 def test_053_override_default_mark():
-    fixture_data = get_text('fixtures/upstream/053-override-default-marks.json')
+    fixture_data = get_fixture('fixtures/upstream/053-override-default-marks.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -265,7 +265,7 @@ def test_053_override_default_mark():
 
 @pytest.mark.skip('Seems to be some sort of regression test')
 def test_060_list_issue():
-    fixture_data = get_text('fixtures/upstream/060-list-issue.json')
+    fixture_data = get_fixture('fixtures/upstream/060-list-issue.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
@@ -273,7 +273,7 @@ def test_060_list_issue():
 
 
 def test_061_missing_mark_serializer():
-    fixture_data = get_text('fixtures/upstream/061-missing-mark-serializer.json')
+    fixture_data = get_fixture('fixtures/upstream/061-missing-mark-serializer.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -6,307 +6,273 @@ import pytest
 from sanity_html import render
 
 
-def test_007_link_mark_def():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '007-link-mark-def.json').read_text())
+def get_text(rel_path) -> dict:
+    """Load and return fixture data as dict."""
+    return json.loads((Path(__file__).parent / rel_path).read_text())
+
+
+def test_001_empty_block():
+    fixture_data = get_text('fixtures/upstream/001-empty-block.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
+
+
+def test_002_single_spa():
+    fixture_data = get_text('fixtures/upstream/002-single-span.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_003_multiple_spa():
+    fixture_data = get_text('fixtures/upstream/003-multiple-spans.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_004_basic_mark_single_spa():
+    fixture_data = get_text('fixtures/upstream/004-basic-mark-single-span.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_005_basic_mark_multiple_adjacent_spa():
+    fixture_data = get_text('fixtures/upstream/005-basic-mark-multiple-adjacent-spans.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_006_basic_mark_nested_mark():
+    fixture_data = get_text('fixtures/upstream/006-basic-mark-nested-marks.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_007_link_mark_def():
+    fixture_data = get_text('fixtures/upstream/007-link-mark-def.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_008_plain_header_block():
+    fixture_data = get_text('fixtures/upstream/008-plain-header-block.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_009_messy_link_text():
+    fixture_data = get_text('fixtures/upstream/009-messy-link-text.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_010_basic_bullet_list():
+    fixture_data = get_text('fixtures/upstream/010-basic-bullet-list.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    print(input_blocks)
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_011_basic_numbered_list():
+    fixture_data = get_text('fixtures/upstream/011-basic-numbered-list.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_012_image_support():
+    fixture_data = get_text('fixtures/upstream/012-image-support.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_013_materialized_image_support():
+    fixture_data = get_text('fixtures/upstream/013-materialized-image-support.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_014_nested_list():
+    fixture_data = get_text('fixtures/upstream/014-nested-lists.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_015_all_basic_mark():
+    fixture_data = get_text('fixtures/upstream/015-all-basic-marks.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_016_deep_weird_list():
+    fixture_data = get_text('fixtures/upstream/016-deep-weird-lists.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_017_all_default_block_style():
+    fixture_data = get_text('fixtures/upstream/017-all-default-block-styles.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
 
 
 @pytest.mark.skip('Requires custom definitions')
 def test_018_marks_all_the_way_dow():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '018-marks-all-the-way-down.json').read_text()
-    )
+    fixture_data = get_text('fixtures/upstream/018-marks-all-the-way-down.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_020_empty_array():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '020-empty-array.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_011_basic_numbered_list():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '011-basic-numbered-list.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_010_basic_bullet_list():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '010-basic-bullet-list.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_002_single_spa():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '002-single-span.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_009_messy_link_text():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '009-messy-link-text.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_003_multiple_spa():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '003-multiple-spans.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_053_override_default_mark():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '053-override-default-marks.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_008_plain_header_block():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '008-plain-header-block.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
 
 
 def test_019_keyle():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '019-keyless.json').read_text())
+    fixture_data = get_text('fixtures/upstream/019-keyless.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
 
 
-def test_005_basic_mark_multiple_adjacent_spa():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '005-basic-mark-multiple-adjacent-spans.json').read_text()
-    )
+def test_020_empty_array():
+    fixture_data = get_text('fixtures/upstream/020-empty-array.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_014_nested_list():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '014-nested-lists.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_027_styled_list_item():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '027-styled-list-items.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
 
 
 def test_021_list_without_level():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '021-list-without-level.json').read_text()
-    )
+    fixture_data = get_text('fixtures/upstream/021-list-without-level.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_013_materialized_image_support():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '013-materialized-image-support.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_061_missing_mark_serializer():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '061-missing-mark-serializer.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_051_override_default():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '051-override-defaults.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_023_hard_break():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '023-hard-breaks.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_016_deep_weird_list():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '016-deep-weird-lists.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_017_all_default_block_style():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '017-all-default-block-styles.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_004_basic_mark_single_spa():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '004-basic-mark-single-span.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
 
 
 def test_022_inline_node():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '022-inline-nodes.json').read_text())
+    fixture_data = get_text('fixtures/upstream/022-inline-nodes.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
+
+
+def test_023_hard_break():
+    fixture_data = get_text('fixtures/upstream/023-hard-breaks.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_024_inline_image():
+    fixture_data = get_text('fixtures/upstream/024-inline-images.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_025_image_with_hotspot():
+    fixture_data = get_text('fixtures/upstream/025-image-with-hotspot.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_026_inline_block_with_text():
+    fixture_data = get_text('fixtures/upstream/026-inline-block-with-text.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_027_styled_list_item():
+    fixture_data = get_text('fixtures/upstream/027-styled-list-items.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_050_custom_block_type():
+    fixture_data = get_text('fixtures/upstream/050-custom-block-type.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_051_override_default():
+    fixture_data = get_text('fixtures/upstream/051-override-defaults.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_052_custom_mark():
+    fixture_data = get_text('fixtures/upstream/052-custom-marks.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
+
+
+def test_053_override_default_mark():
+    fixture_data = get_text('fixtures/upstream/053-override-default-marks.json')
+    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
+    expected_output = fixture_data['output']
+    output = render(input_blocks)
+    assert output == expected_output
 
 
 @pytest.mark.skip('Seems to be some sort of regression test')
 def test_060_list_issue():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '060-list-issue.json').read_text())
+    fixture_data = get_text('fixtures/upstream/060-list-issue.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output
 
 
-def test_025_image_with_hotspot():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '025-image-with-hotspot.json').read_text()
-    )
+def test_061_missing_mark_serializer():
+    fixture_data = get_text('fixtures/upstream/061-missing-mark-serializer.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
     expected_output = fixture_data['output']
     output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_050_custom_block_type():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '050-custom-block-type.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_015_all_basic_mark():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '015-all-basic-marks.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_001_empty_block():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '001-empty-block.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_024_inline_image():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '024-inline-images.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_026_inline_block_with_text():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '026-inline-block-with-text.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_052_custom_mark():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '052-custom-marks.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_006_basic_mark_nested_mark():
-    fixture_data = json.loads(
-        (Path(__file__).parent / 'fixtures' / 'upstream' / '006-basic-mark-nested-marks.json').read_text()
-    )
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
-
-
-def test_012_image_support():
-    fixture_data = json.loads((Path(__file__).parent / 'fixtures' / 'upstream' / '012-image-support.json').read_text())
-    input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    expected_output = fixture_data['output']
-    output = render(input_blocks)
-    assert expected_output == output
+    assert output == expected_output

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -75,6 +75,9 @@ def test_008_plain_header_block():
     assert output == expected_output
 
 
+# Fails because of mark ordering
+# expected: <strong><em>app</strong> or website</a></em>.</blockquote>
+# output:   <em><strong>app</strong> or website</em></a>.</blockquote>
 def test_009_messy_link_text():
     fixture_data = get_text('fixtures/upstream/009-messy-link-text.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
@@ -86,7 +89,6 @@ def test_009_messy_link_text():
 def test_010_basic_bullet_list():
     fixture_data = get_text('fixtures/upstream/010-basic-bullet-list.json')
     input_blocks = [fixture_data['input']] if type(fixture_data['input']) == dict else fixture_data['input']
-    print(input_blocks)
     expected_output = fixture_data['output']
     output = render(input_blocks)
     assert output == expected_output


### PR DESCRIPTION
Adds missing default decorator markers not mentioned in the spec, but defined in the [block-content-to-hyperscript](https://github.com/sanity-io/block-content-to-hyperscript/blob/master/src/buildMarksTree.js#L1) package. 

![image](https://user-images.githubusercontent.com/25310870/114748215-f8fa5800-9d51-11eb-9760-776de5236216.png)
 