### PR TITLE
Add _render_image method

### DIFF
--- a/sanity_html/renderer.py
+++ b/sanity_html/renderer.py
@@ -88,17 +88,17 @@ class SanityBlockRenderer:
             return ''
 
     def _render_block(self, block: Block, list_item: bool = False) -> str:
-        text = ''
-        if not list_item:
-            tag = STYLE_MAP[block.style]
+        text, tag = '', STYLE_MAP[block.style]
+
+        if not list_item or tag != 'p':
             text += f'<{tag}>'
 
-            for child_node in block.children:
-                text += self._render_node(child_node, context=block)
+        for child_node in block.children:
+            text += self._render_node(child_node, context=block)
+
+        if not list_item or tag != 'p':
             text += f'</{tag}>'
-        else:
-            for child_node in block.children:
-                text += self._render_node(child_node, context=block)
+
         return text
 
     def _render_span(self, span: Span, block: Block) -> str:

--- a/sanity_html/renderer.py
+++ b/sanity_html/renderer.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import html
+import logging
 from typing import TYPE_CHECKING
 
 from sanity_html.constants import STYLE_MAP
 from sanity_html.dataclasses import Block, Span
 from sanity_html.marker_definitions import DefaultMarkerDefinition
-from sanity_html.utils import get_list_tags, is_block, is_list, is_span
+from sanity_html.utils import get_list_tags, is_block, is_image, is_list, is_span
 
 if TYPE_CHECKING:
     from typing import Dict, List, Optional, Union
+
+logger = logging.getLogger('python_sanity_html')
 
 
 # TODO: Let user pass custom code block definitions/plugins
@@ -36,16 +39,17 @@ class SanityBlockRenderer:
         result = ''
         list_nodes: List[Dict] = []
         for node in self._blocks:
-
             if list_nodes and not is_list(node):
                 result += self._render_list(list_nodes)
                 list_nodes = []  # reset list_nodes
 
             if is_list(node):
                 list_nodes.append(node)
-                continue  # handle all elements ^ when the list ends
-
-            result += self._render_node(node)  # render non-list nodes immediately
+                # handle all elements ^ when the list ends
+            elif is_image(node):
+                result += self._render_image(node)
+            else:
+                result += self._render_node(node)  # render non-list nodes immediately
 
         if list_nodes:
             result += self._render_list(list_nodes)
@@ -154,6 +158,15 @@ class SanityBlockRenderer:
             result += value
 
         return result
+
+    def _render_image(self, node: dict) -> str:
+        """Images are currently not supported, but should be added in the future.
+
+        The biggest blocker seems to be that we require a python-based image url-builder
+        which would be another project, mimicking https://github.com/sanity-io/image-url.
+        """
+        logger.warning('Skipping image rendering. Image rendering is not yet implemented.')
+        return ''
 
 
 def render(blocks: List[Dict]) -> str:

--- a/sanity_html/utils.py
+++ b/sanity_html/utils.py
@@ -41,6 +41,11 @@ def is_block(node: dict) -> bool:
     return node.get('_type') == 'block' and 'listItem' not in node
 
 
+def is_image(node: dict) -> bool:
+    """Check whether a node is an image node."""
+    return node.get('_type') == 'image'
+
+
 def get_list_tags(list_item: str) -> tuple[str, str]:
     """Return the appropriate list tags for a given list item."""
     # TODO: Make it possible for users to pass their own maps, perhaps by adding this to the class

--- a/tests/fixtures/upstream/012-image-support.json
+++ b/tests/fixtures/upstream/012-image-support.json
@@ -1,1 +1,26 @@
-{"input":[{"style":"normal","_type":"block","_key":"bd73ec5f61a1","markDefs":[],"children":[{"_type":"span","text":"Also, images are pretty common.","marks":[]}]},{"_type":"image","_key":"d234a4fa317a","asset":{"_type":"reference","_ref":"image-YiOKD0O6AdjKPaK24WtbOEv0-3456x2304-jpg"}}],"output":"<div><p>Also, images are pretty common.</p><figure><img src=\"https://cdn.sanity.io/images/3do82whm/production/YiOKD0O6AdjKPaK24WtbOEv0-3456x2304.jpg\"/></figure></div>"}
+{
+  "input": [
+    {
+      "style": "normal",
+      "_type": "block",
+      "_key": "bd73ec5f61a1",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Also, images are pretty common.",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "_type": "image",
+      "_key": "d234a4fa317a",
+      "asset": {
+        "_type": "reference",
+        "_ref": "image-YiOKD0O6AdjKPaK24WtbOEv0-3456x2304-jpg"
+      }
+    }
+  ],
+  "output": "<div><p>Also, images are pretty common.</p><figure><img src=\"https://cdn.sanity.io/images/3do82whm/production/YiOKD0O6AdjKPaK24WtbOEv0-3456x2304.jpg\"/></figure></div>"
+}

--- a/tests/fixtures/upstream/027-styled-list-items.json
+++ b/tests/fixtures/upstream/027-styled-list-items.json
@@ -1,1 +1,63 @@
-{"input":[{"style":"normal","_type":"block","_key":"f94596b05b41","markDefs":[],"children":[{"_type":"span","text":"Let's test some of these lists!","marks":[]}]},{"listItem":"bullet","style":"normal","level":1,"_type":"block","_key":"937effb1cd06","markDefs":[],"children":[{"_type":"span","text":"Bullet 1","marks":[]}]},{"listItem":"bullet","style":"h1","level":1,"_type":"block","_key":"bd2d22278b88","markDefs":[],"children":[{"_type":"span","text":"Bullet 2","marks":[]}]},{"listItem":"bullet","style":"normal","level":1,"_type":"block","_key":"a97d32e9f747","markDefs":[],"children":[{"_type":"span","text":"Bullet 3","marks":[]}]}],"output":"<div><p>Let&#x27;s test some of these lists!</p><ul><li>Bullet 1</li><li><h1>Bullet 2</h1></li><li>Bullet 3</li></ul></div>"}
+{
+  "input": [
+    {
+      "style": "normal",
+      "_type": "block",
+      "_key": "f94596b05b41",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Let's test some of these lists!",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "listItem": "bullet",
+      "style": "normal",
+      "level": 1,
+      "_type": "block",
+      "_key": "937effb1cd06",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Bullet 1",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "listItem": "bullet",
+      "style": "h1",
+      "level": 1,
+      "_type": "block",
+      "_key": "bd2d22278b88",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Bullet 2",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "listItem": "bullet",
+      "style": "normal",
+      "level": 1,
+      "_type": "block",
+      "_key": "a97d32e9f747",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Bullet 3",
+          "marks": []
+        }
+      ]
+    }
+  ],
+  "output": "<div><p>Let&#x27;s test some of these lists!</p><ul><li>Bullet 1</li><li><h1>Bullet 2</h1></li><li>Bullet 3</li></ul></div>"
+}

--- a/tests/fixtures/upstream/053-override-default-marks.json
+++ b/tests/fixtures/upstream/053-override-default-marks.json
@@ -1,1 +1,23 @@
-{"input":{"_type":"block","children":[{"_key":"a1ph4","_type":"span","marks":["mark1"],"text":"Sanity"}],"markDefs":[{"_key":"mark1","_type":"link","href":"https://sanity.io"}]},"output":"<p><a class=\"mahlink\" href=\"https://sanity.io\">Sanity</a></p>"}
+{
+  "input": {
+    "_type": "block",
+    "children": [
+      {
+        "_key": "a1ph4",
+        "_type": "span",
+        "marks": [
+          "mark1"
+        ],
+        "text": "Sanity"
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "mark1",
+        "_type": "link",
+        "href": "https://sanity.io"
+      }
+    ]
+  },
+  "output": "<p><a class=\"mahlink\" href=\"https://sanity.io\">Sanity</a></p>"
+}


### PR DESCRIPTION
Took a quick look at the image type, and from what I can tell, I guess our primary obstacle will be generating this
```
"https://cdn.sanity.io/images/3do82whm/production/YiOKD0O6AdjKPaK24WtbOEv0-3456x2304.jpg"
```

from this
```
"image-YiOKD0O6AdjKPaK24WtbOEv0-3456x2304-jpg"
```

As we've discussed, it doesn't seem like something we need badly enough to prioritize in the short-term, but I thought it might make sense to set up the code flow and add some documentation to make it clear why it's unhandled. 