### PR TITLE
Add style to lists, except for p tags

### DIFF
--- a/sanity_html/renderer.py
+++ b/sanity_html/renderer.py
@@ -88,17 +88,17 @@ class SanityBlockRenderer:
             return ''
 
     def _render_block(self, block: Block, list_item: bool = False) -> str:
-        text = ''
-        if not list_item:
-            tag = STYLE_MAP[block.style]
+        text, tag = '', STYLE_MAP[block.style]
+
+        if not list_item or tag != 'p':
             text += f'<{tag}>'
 
-            for child_node in block.children:
-                text += self._render_node(child_node, context=block)
+        for child_node in block.children:
+            text += self._render_node(child_node, context=block)
+
+        if not list_item or tag != 'p':
             text += f'</{tag}>'
-        else:
-            for child_node in block.children:
-                text += self._render_node(child_node, context=block)
+
         return text
 
     def _render_span(self, span: Span, block: Block) -> str:

--- a/tests/fixtures/upstream/027-styled-list-items.json
+++ b/tests/fixtures/upstream/027-styled-list-items.json
@@ -1,1 +1,63 @@
-{"input":[{"style":"normal","_type":"block","_key":"f94596b05b41","markDefs":[],"children":[{"_type":"span","text":"Let's test some of these lists!","marks":[]}]},{"listItem":"bullet","style":"normal","level":1,"_type":"block","_key":"937effb1cd06","markDefs":[],"children":[{"_type":"span","text":"Bullet 1","marks":[]}]},{"listItem":"bullet","style":"h1","level":1,"_type":"block","_key":"bd2d22278b88","markDefs":[],"children":[{"_type":"span","text":"Bullet 2","marks":[]}]},{"listItem":"bullet","style":"normal","level":1,"_type":"block","_key":"a97d32e9f747","markDefs":[],"children":[{"_type":"span","text":"Bullet 3","marks":[]}]}],"output":"<div><p>Let&#x27;s test some of these lists!</p><ul><li>Bullet 1</li><li><h1>Bullet 2</h1></li><li>Bullet 3</li></ul></div>"}
+{
+  "input": [
+    {
+      "style": "normal",
+      "_type": "block",
+      "_key": "f94596b05b41",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Let's test some of these lists!",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "listItem": "bullet",
+      "style": "normal",
+      "level": 1,
+      "_type": "block",
+      "_key": "937effb1cd06",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Bullet 1",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "listItem": "bullet",
+      "style": "h1",
+      "level": 1,
+      "_type": "block",
+      "_key": "bd2d22278b88",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Bullet 2",
+          "marks": []
+        }
+      ]
+    },
+    {
+      "listItem": "bullet",
+      "style": "normal",
+      "level": 1,
+      "_type": "block",
+      "_key": "a97d32e9f747",
+      "markDefs": [],
+      "children": [
+        {
+          "_type": "span",
+          "text": "Bullet 3",
+          "marks": []
+        }
+      ]
+    }
+  ],
+  "output": "<div><p>Let&#x27;s test some of these lists!</p><ul><li>Bullet 1</li><li><h1>Bullet 2</h1></li><li>Bullet 3</li></ul></div>"
+}


### PR DESCRIPTION
Fixes upstream test 27.

Looks like the rule is that block style tags should be added to lists, except if the style is normal.