### PR TITLE
Fix two more tests

### DIFF
--- a/sanity_html/marker_definitions.py
+++ b/sanity_html/marker_definitions.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Type
 
-    from sanity_html.dataclasses import Block, Span
+    from sanity_html.types import Block, Span
 
 
 class MarkerDefinition:

--- a/sanity_html/types.py
+++ b/sanity_html/types.py
@@ -38,7 +38,7 @@ class Block:
     _type: Literal['block']
 
     _key: Optional[str] = None
-    style: Literal['h1', 'h2', 'h3', 'h4', 'normal'] = 'normal'
+    style: Literal['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'normal'] = 'normal'
     level: Optional[int] = None
     listItem: Optional[Literal['bullet', 'number', 'square']] = None
     children: list[dict] = field(default_factory=list)

--- a/sanity_html/utils.py
+++ b/sanity_html/utils.py
@@ -20,8 +20,9 @@ def get_default_marker_definitions(mark_defs: list[dict]) -> dict[str, Type[Mark
     marker_definitions = {}
 
     for definition in mark_defs:
-        marker = ANNOTATION_MARKER_DEFINITIONS[definition['_type']]
-        marker_definitions[definition['_key']] = marker
+        if definition['_type'] in ANNOTATION_MARKER_DEFINITIONS:
+            marker = ANNOTATION_MARKER_DEFINITIONS[definition['_type']]
+            marker_definitions[definition['_key']] = marker
 
     return {**marker_definitions, **DECORATOR_MARKER_DEFINITIONS}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ ignore=
     ANN101,
     # W503 line break before binary operator
     W503,
+    # ANN002 and ANN003 missing type annotation for *args and **kwargs
+    ANN002, ANN003
 
 select =
     E, F, N, W

--- a/tests/fixtures/upstream/052-custom-marks.json
+++ b/tests/fixtures/upstream/052-custom-marks.json
@@ -1,1 +1,23 @@
-{"input":{"_type":"block","children":[{"_key":"a1ph4","_type":"span","marks":["mark1"],"text":"Sanity"}],"markDefs":[{"_key":"mark1","_type":"highlight","thickness":5}]},"output":"<p><span style=\"border:5px solid;\">Sanity</span></p>"}
+{
+  "input": {
+    "_type": "block",
+    "children": [
+      {
+        "_key": "a1ph4",
+        "_type": "span",
+        "marks": [
+          "mark1"
+        ],
+        "text": "Sanity"
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "mark1",
+        "_type": "highlight",
+        "thickness": 5
+      }
+    ]
+  },
+  "output": "<p><span style=\"border:5px solid;\">Sanity</span></p>"
+}

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -1,4 +1,3 @@
-from sanity_html.dataclasses import Block, Span
 from sanity_html.marker_definitions import (
     CommentMarkerDefinition,
     EmphasisMarkerDefinition,
@@ -7,6 +6,7 @@ from sanity_html.marker_definitions import (
     StrongMarkerDefinition,
     UnderlineMarkerDefinition,
 )
+from sanity_html.types import Block, Span
 
 sample_texts = ['test', None, 1, 2.2, '!"#$%&/()']
 

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -1,14 +1,14 @@
 import json
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Type
 
 import pytest
 
 from sanity_html import render
-from sanity_html.dataclasses import Block
 from sanity_html.marker_definitions import LinkMarkerDefinition, MarkerDefinition
 from sanity_html.renderer import SanityBlockRenderer
+from sanity_html.types import Block, Span
 
 
 def fake_image_serializer(node: dict, context: Optional[Block], list_item: bool):
@@ -300,7 +300,15 @@ def test_052_custom_mark():
     fixture_data = get_fixture('fixtures/upstream/052-custom-marks.json')
     input_blocks = fixture_data['input']
     expected_output = fixture_data['output']
-    output = render(input_blocks)
+
+    class CustomMarkerSerializer(MarkerDefinition):
+        tag = 'span'
+
+        @classmethod
+        def render_prefix(cls, span: Span, marker: str, context: Block) -> str:
+            return '<span style="border:5px solid;">'
+
+    output = render(input_blocks, custom_marker_definitions={'mark1': CustomMarkerSerializer})
     assert output == expected_output
 
 


### PR DESCRIPTION
## Changes

- Renames `dataclasses` to `types`. This seems in line with the terminology we want to move towards (where a block-serializer is referred to as a type serializer).
- Re-implements changes made to `_render_block` in https://github.com/otovo/python-sanity-html/pull/9/files. Looks like the changes were overwritten.
- Adds a custom marker definition to upstream test 52. 

The last two points fix a test each, leaving us with just 5 broken tests remaining 👍 
