### PR TITLE
Rename MarkerDefinition to MarkerSerializer

### DIFF
--- a/sanity_html/constants.py
+++ b/sanity_html/constants.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sanity_html.marker_definitions import (
-    CodeMarkerDefinition,
-    CommentMarkerDefinition,
-    EmphasisMarkerDefinition,
-    LinkMarkerDefinition,
-    StrikeThroughMarkerDefinition,
-    StrongMarkerDefinition,
-    UnderlineMarkerDefinition,
+from sanity_html.marker_serializers import (
+    CodeSerializer,
+    CommentSerializer,
+    EmphasisSerializer,
+    LinkSerializer,
+    StrikeThroughSerializer,
+    StrongSerializer,
+    UnderlineSerializer,
 )
 
 if TYPE_CHECKING:
     from typing import Dict, Type
 
-    from sanity_html.marker_definitions import MarkerDefinition
+    from sanity_html.marker_serializers import MarkerSerializer
 
 STYLE_MAP = {
     'h1': 'h1',
@@ -28,15 +28,15 @@ STYLE_MAP = {
     'normal': 'p',
 }
 
-DECORATOR_MARKER_DEFINITIONS: Dict[str, Type[MarkerDefinition]] = {
-    'em': EmphasisMarkerDefinition,
-    'strong': StrongMarkerDefinition,
-    'code': CodeMarkerDefinition,
-    'underline': UnderlineMarkerDefinition,
-    'strike-through': StrikeThroughMarkerDefinition,
+DECORATOR_MARKER_SERIALIZERS: Dict[str, Type[MarkerSerializer]] = {
+    'em': EmphasisSerializer,
+    'strong': StrongSerializer,
+    'code': CodeSerializer,
+    'underline': UnderlineSerializer,
+    'strike-through': StrikeThroughSerializer,
 }
 
-ANNOTATION_MARKER_DEFINITIONS: Dict[str, Type[MarkerDefinition]] = {
-    'link': LinkMarkerDefinition,
-    'comment': CommentMarkerDefinition,
+ANNOTATION_MARKER_SERIALIZERS: Dict[str, Type[MarkerSerializer]] = {
+    'link': LinkSerializer,
+    'comment': CommentSerializer,
 }

--- a/sanity_html/marker_serializers.py
+++ b/sanity_html/marker_serializers.py
@@ -8,13 +8,13 @@ if TYPE_CHECKING:
     from sanity_html.types import Block, Span
 
 
-class MarkerDefinition:
+class MarkerSerializer:
     """Base class for marker definition handlers."""
 
     tag: str
 
     @classmethod
-    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render_prefix(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the prefix for the marked span.
 
         Usually this this the opening of the HTML tag.
@@ -22,7 +22,7 @@ class MarkerDefinition:
         return f'<{cls.tag}>'
 
     @classmethod
-    def render_suffix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render_suffix(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the suffix for the marked span.
 
         Usually this this the closing of the HTML tag.
@@ -30,7 +30,7 @@ class MarkerDefinition:
         return f'</{cls.tag}>'
 
     @classmethod
-    def render(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the marked span directly with prefix and suffix."""
         result = cls.render_prefix(span, marker, context)
         result += str(span.text)
@@ -41,42 +41,42 @@ class MarkerDefinition:
 # Decorators
 
 
-class DefaultMarkerDefinition(MarkerDefinition):
+class DefaultMarkerSerializer(MarkerSerializer):
     """Marker used for unknown definitions."""
 
     tag = 'span'
 
 
-class EmphasisMarkerDefinition(MarkerDefinition):
+class EmphasisSerializer(MarkerSerializer):
     """Marker definition for <em> rendering."""
 
     tag = 'em'
 
 
-class StrongMarkerDefinition(MarkerDefinition):
+class StrongSerializer(MarkerSerializer):
     """Marker definition for <strong> rendering."""
 
     tag = 'strong'
 
 
-class CodeMarkerDefinition(MarkerDefinition):
+class CodeSerializer(MarkerSerializer):
     """Marker definition for <code> rendering."""
 
     tag = 'code'
 
 
-class UnderlineMarkerDefinition(MarkerDefinition):
+class UnderlineSerializer(MarkerSerializer):
     """Marker definition for <u> rendering."""
 
     tag = 'span'
 
     @classmethod
-    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render_prefix(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the span with the appropriate style for underline."""
         return '<span style="text-decoration:underline;">'
 
 
-class StrikeThroughMarkerDefinition(MarkerDefinition):
+class StrikeThroughSerializer(MarkerSerializer):
     """Marker definition for <strike> rendering."""
 
     tag = 'del'
@@ -85,13 +85,13 @@ class StrikeThroughMarkerDefinition(MarkerDefinition):
 # Annotations
 
 
-class LinkMarkerDefinition(MarkerDefinition):
+class LinkSerializer(MarkerSerializer):
     """Marker definition for link rendering."""
 
     tag = 'a'
 
     @classmethod
-    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render_prefix(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the opening anchor tag with the href attribute set.
 
         The href attribute is fetched from the provided block context using
@@ -104,17 +104,17 @@ class LinkMarkerDefinition(MarkerDefinition):
         return f'<a href="{href}">'
 
 
-class CommentMarkerDefinition(MarkerDefinition):
+class CommentSerializer(MarkerSerializer):
     """Marker definition for HTML comment rendering."""
 
     tag = '!--'
 
     @classmethod
-    def render_prefix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render_prefix(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the opening of the HTML comment block."""
         return '<!-- '
 
     @classmethod
-    def render_suffix(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+    def render_suffix(cls: Type[MarkerSerializer], span: Span, marker: str, context: Block) -> str:
         """Render the closing part of the HTML comment block."""
         return ' -->'

--- a/sanity_html/renderer.py
+++ b/sanity_html/renderer.py
@@ -4,14 +4,14 @@ import html
 from typing import TYPE_CHECKING
 
 from sanity_html.constants import STYLE_MAP
-from sanity_html.marker_definitions import DefaultMarkerDefinition
+from sanity_html.marker_serializers import DefaultMarkerSerializer
 from sanity_html.types import Block, Span
 from sanity_html.utils import get_list_tags, is_block, is_list, is_span
 
 if TYPE_CHECKING:
     from typing import Callable, Dict, List, Optional, Type, Union
 
-    from sanity_html.marker_definitions import MarkerDefinition
+    from sanity_html.marker_serializers import MarkerSerializer
 
 
 class SanityBlockRenderer:
@@ -20,7 +20,7 @@ class SanityBlockRenderer:
     def __init__(
         self,
         blocks: Union[list[dict], dict],
-        custom_marker_definitions: dict[str, Type[MarkerDefinition]] = None,
+        custom_marker_definitions: dict[str, Type[MarkerSerializer]] = None,
         custom_serializers: dict[str, Callable[[dict, Optional[Block], bool], str]] = None,
     ) -> None:
         self._wrapper_element: Optional[str] = None
@@ -74,7 +74,7 @@ class SanityBlockRenderer:
         """
         if is_list(node):
             block = Block(**node, marker_definitions=self._custom_marker_definitions)
-            return self._render_list(block, context)
+            return self._render_list(block)
         elif is_block(node):
             block = Block(**node, marker_definitions=self._custom_marker_definitions)
             return self._render_block(block, list_item=list_item)
@@ -119,7 +119,7 @@ class SanityBlockRenderer:
         for mark in sorted_marks:
             if mark in prev_marks:
                 continue
-            marker_callable = block.marker_definitions.get(mark, DefaultMarkerDefinition)()
+            marker_callable = block.marker_definitions.get(mark, DefaultMarkerSerializer)()
             result += marker_callable.render_prefix(span, mark, block)
 
         result += html.escape(span.text).replace('\n', '<br/>')
@@ -128,12 +128,12 @@ class SanityBlockRenderer:
             if mark in next_marks:
                 continue
 
-            marker_callable = block.marker_definitions.get(mark, DefaultMarkerDefinition)()
+            marker_callable = block.marker_definitions.get(mark, DefaultMarkerSerializer)()
             result += marker_callable.render_suffix(span, mark, block)
 
         return result
 
-    def _render_list(self, node: Block, context: Optional[Block]) -> str:
+    def _render_list(self, node: Block) -> str:
         assert node.listItem
         head, tail = get_list_tags(node.listItem)
         result = head

--- a/sanity_html/types.py
+++ b/sanity_html/types.py
@@ -8,7 +8,7 @@ from sanity_html.utils import get_default_marker_definitions
 if TYPE_CHECKING:
     from typing import Literal, Optional, Tuple, Type, Union
 
-    from sanity_html.marker_definitions import MarkerDefinition
+    from sanity_html.marker_serializers import MarkerSerializer
 
 
 @dataclass(frozen=True)
@@ -43,7 +43,7 @@ class Block:
     listItem: Optional[Literal['bullet', 'number', 'square']] = None
     children: list[dict] = field(default_factory=list)
     markDefs: list[dict] = field(default_factory=list)
-    marker_definitions: dict[str, Type[MarkerDefinition]] = field(default_factory=dict)
+    marker_definitions: dict[str, Type[MarkerSerializer]] = field(default_factory=dict)
     marker_frequencies: dict[str, int] = field(init=False)
 
     def __post_init__(self) -> None:

--- a/sanity_html/utils.py
+++ b/sanity_html/utils.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sanity_html.constants import ANNOTATION_MARKER_DEFINITIONS, DECORATOR_MARKER_DEFINITIONS
+from sanity_html.constants import ANNOTATION_MARKER_SERIALIZERS, DECORATOR_MARKER_SERIALIZERS
 
 if TYPE_CHECKING:
     from typing import Type
 
-    from sanity_html.marker_definitions import MarkerDefinition
+    from sanity_html.marker_serializers import MarkerSerializer
 
 
-def get_default_marker_definitions(mark_defs: list[dict]) -> dict[str, Type[MarkerDefinition]]:
+def get_default_marker_definitions(mark_defs: list[dict]) -> dict[str, Type[MarkerSerializer]]:
     """
     Convert JSON definitions to a map of marker definition renderers.
 
@@ -20,11 +20,11 @@ def get_default_marker_definitions(mark_defs: list[dict]) -> dict[str, Type[Mark
     marker_definitions = {}
 
     for definition in mark_defs:
-        if definition['_type'] in ANNOTATION_MARKER_DEFINITIONS:
-            marker = ANNOTATION_MARKER_DEFINITIONS[definition['_type']]
+        if definition['_type'] in ANNOTATION_MARKER_SERIALIZERS:
+            marker = ANNOTATION_MARKER_SERIALIZERS[definition['_type']]
             marker_definitions[definition['_key']] = marker
 
-    return {**marker_definitions, **DECORATOR_MARKER_DEFINITIONS}
+    return {**marker_definitions, **DECORATOR_MARKER_SERIALIZERS}
 
 
 def is_list(node: dict) -> bool:

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -1,10 +1,10 @@
-from sanity_html.marker_definitions import (
-    CommentMarkerDefinition,
-    EmphasisMarkerDefinition,
-    LinkMarkerDefinition,
-    StrikeThroughMarkerDefinition,
-    StrongMarkerDefinition,
-    UnderlineMarkerDefinition,
+from sanity_html.marker_serializers import (
+    CommentSerializer,
+    EmphasisSerializer,
+    LinkSerializer,
+    StrikeThroughSerializer,
+    StrongSerializer,
+    UnderlineSerializer,
 )
 from sanity_html.types import Block, Span
 
@@ -15,31 +15,28 @@ def test_render_emphasis_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
-        assert EmphasisMarkerDefinition.render(node, 'em', block) == f'<em>{text}</em>'
+        assert EmphasisSerializer.render(node, 'em', block) == f'<em>{text}</em>'
 
 
 def test_render_strong_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
-        assert StrongMarkerDefinition.render(node, 'strong', block) == f'<strong>{text}</strong>'
+        assert StrongSerializer.render(node, 'strong', block) == f'<strong>{text}</strong>'
 
 
 def test_render_underline_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
-        assert (
-            UnderlineMarkerDefinition.render(node, 'u', block)
-            == f'<span style="text-decoration:underline;">{text}</span>'
-        )
+        assert UnderlineSerializer.render(node, 'u', block) == f'<span style="text-decoration:underline;">{text}</span>'
 
 
 def test_render_strikethrough_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
-        assert StrikeThroughMarkerDefinition.render(node, 'strike', block) == f'<del>{text}</del>'
+        assert StrikeThroughSerializer.render(node, 'strike', block) == f'<del>{text}</del>'
 
 
 def test_render_link_marker_success():
@@ -48,11 +45,11 @@ def test_render_link_marker_success():
         block = Block(
             _type='block', children=[node.__dict__], markDefs=[{'_type': 'link', '_key': 'linkId', 'href': text}]
         )
-        assert LinkMarkerDefinition.render(node, 'linkId', block) == f'<a href="{text}">{text}</a>'
+        assert LinkSerializer.render(node, 'linkId', block) == f'<a href="{text}">{text}</a>'
 
 
 def test_render_comment_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
-        assert CommentMarkerDefinition.render(node, 'comment', block) == f'<!-- {text} -->'
+        assert CommentSerializer.render(node, 'comment', block) == f'<!-- {text} -->'

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -6,7 +6,7 @@ from typing import Optional, Type
 import pytest
 
 from sanity_html import render
-from sanity_html.marker_definitions import LinkMarkerDefinition, MarkerDefinition
+from sanity_html.marker_serializers import LinkSerializer, MarkerSerializer
 from sanity_html.renderer import SanityBlockRenderer
 from sanity_html.types import Block, Span
 
@@ -301,7 +301,7 @@ def test_052_custom_mark():
     input_blocks = fixture_data['input']
     expected_output = fixture_data['output']
 
-    class CustomMarkerSerializer(MarkerDefinition):
+    class CustomMarkerSerializer(MarkerSerializer):
         tag = 'span'
 
         @classmethod
@@ -317,7 +317,7 @@ def test_053_override_default_mark():
     input_blocks = fixture_data['input']
     expected_output = fixture_data['output']
 
-    class CustomLinkMark(LinkMarkerDefinition):
+    class CustomLinkMark(LinkSerializer):
         @classmethod
         def render_prefix(cls, span, marker, context) -> str:
             result = super().render_prefix(span, marker, context)


### PR DESCRIPTION
Renames marker definitions to serializers, as per #11. 

Reworking the types + _parse methods to a serializer format is clearly a bigger task, so this is just meant as a step in the right direction.