### PR TITLE
Test 21

### DIFF
--- a/sanity_html/logger.py
+++ b/sanity_html/logger.py
@@ -1,0 +1,12 @@
+import logging
+import sys
+
+logger = logging.getLogger('sanity_html')
+
+# Make logger output to stdout
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)

--- a/sanity_html/marker_definitions.py
+++ b/sanity_html/marker_definitions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sanity_html.logger import logger
+
 if TYPE_CHECKING:
     from typing import Type
 
@@ -19,6 +21,7 @@ class MarkerDefinition:
 
         Usually this this the opening of the HTML tag.
         """
+        logger.debug('Rendering %s prefix', cls.tag)
         return f'<{cls.tag}>'
 
     @classmethod
@@ -27,6 +30,7 @@ class MarkerDefinition:
 
         Usually this this the closing of the HTML tag.
         """
+        logger.debug('Rendering %s suffix', cls.tag)
         return f'</{cls.tag}>'
 
     @classmethod

--- a/sanity_html/renderer.py
+++ b/sanity_html/renderer.py
@@ -4,6 +4,7 @@ import html
 from typing import TYPE_CHECKING
 
 from sanity_html.constants import STYLE_MAP
+from sanity_html.logger import logger
 from sanity_html.marker_definitions import DefaultMarkerDefinition
 from sanity_html.types import Block, Span
 from sanity_html.utils import get_list_tags, is_block, is_list, is_span
@@ -23,6 +24,7 @@ class SanityBlockRenderer:
         custom_marker_definitions: dict[str, Type[MarkerDefinition]] = None,
         custom_serializers: dict[str, Callable[[dict, Optional[Block], bool], str]] = None,
     ) -> None:
+        logger.debug('Initializing block renderer')
         self._wrapper_element: Optional[str] = None
         self._custom_marker_definitions = custom_marker_definitions or {}
         self._custom_serializers = custom_serializers or {}
@@ -35,6 +37,7 @@ class SanityBlockRenderer:
 
     def render(self) -> str:
         """Render HTML from self._blocks."""
+        logger.debug('Rendering HTML')
         if not self._blocks:
             return ''
 
@@ -73,19 +76,17 @@ class SanityBlockRenderer:
         :param list_item: Whether we are handling a list upstream (impacts block handling).
         """
         if is_list(node):
+            logger.debug('Rendering node as list')
             block = Block(**node, marker_definitions=self._custom_marker_definitions)
             return self._render_list(block, context)
         elif is_block(node):
+            logger.debug('Rendering node as block')
             block = Block(**node, marker_definitions=self._custom_marker_definitions)
             return self._render_block(block, list_item=list_item)
 
         elif is_span(node):
-            if isinstance(node, str):
-                # TODO: Remove if we there's no coverage for this after we've fixed tests
-                #  not convinced this code path is possible - put it in because the sanity lib checks for it
-                span = Span(**{'text': node})
-            else:
-                span = Span(**node)
+            logger.debug('Rendering node as span')
+            span = Span(**node)
 
             assert context  # this should be a cast
             return self._render_span(span, block=context)  # context is span's outer block
@@ -110,8 +111,10 @@ class SanityBlockRenderer:
         return text
 
     def _render_span(self, span: Span, block: Block) -> str:
+        logger.debug('Rendering span')
         result: str = ''
         prev_node, next_node = block.get_node_siblings(span)
+
         prev_marks = prev_node.get('marks', []) if prev_node else []
         next_marks = next_node.get('marks', []) if next_node else []
 

--- a/sanity_html/types.py
+++ b/sanity_html/types.py
@@ -87,9 +87,9 @@ class Block:
         prev_node = None
         next_node = None
 
-        if node_idx >= 1:
+        if node_idx != 0:
             prev_node = self.children[node_idx - 1]
-        if node_idx < len(self.children) - 2:
+        if node_idx != len(self.children) - 1:
             next_node = self.children[node_idx + 1]
 
         return prev_node, next_node

--- a/sanity_html/types.py
+++ b/sanity_html/types.py
@@ -73,14 +73,18 @@ class Block:
         if not self.children:
             return None, None
         try:
-            if not isinstance(node, (dict, Span)):
-                raise ValueError(f'Expected dict or Span but received {type(node)}')
-            elif type(node) == dict:
+            if type(node) == dict:
                 node = cast(dict, node)
                 node_idx = self.children.index(node)
             elif type(node) == Span:
                 node = cast(Span, node)
-                node_idx = self.children.index(next((c for c in self.children if c.get('_key') == node._key), {}))
+                for index, item in enumerate(self.children):
+                    if 'text' in item and node.text == item['text']:
+                        # Is it possible to handle several identical texts?
+                        node_idx = index
+                        break
+            else:
+                raise ValueError(f'Expected dict or Span but received {type(node)}')
         except ValueError:
             return None, None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ ignore=
     W503,
     # ANN002 and ANN003 missing type annotation for *args and **kwargs
     ANN002, ANN003
+    # SM106 - Handle error cases first
+    SIM106
 
 select =
     E, F, N, W

--- a/tests/fixtures/upstream/021-list-without-level.json
+++ b/tests/fixtures/upstream/021-list-without-level.json
@@ -1,1 +1,284 @@
-{"input":[{"_key":"e3ac53b5b339","_type":"block","children":[{"_type":"span","marks":[],"text":"In-person access: Research appointments"}],"markDefs":[],"style":"h2"},{"_key":"a25f0be55c47","_type":"block","children":[{"_type":"span","marks":[],"text":"The collection may be examined by arranging a research appointment "},{"_type":"span","marks":["strong"],"text":"in advance"},{"_type":"span","marks":[],"text":" by contacting the ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research appointments at any time. Appointment scheduling is subject to institute holidays and closings. "}],"markDefs":[],"style":"normal"},{"_key":"9490a3085498","_type":"block","children":[{"_type":"span","marks":[],"text":"The collection space is located at:\n20 Ames Street\nBuilding E15-235\nCambridge, Massachusetts 02139"}],"markDefs":[],"style":"normal"},{"_key":"4c37f3bc1d71","_type":"block","children":[{"_type":"span","marks":[],"text":"In-person access: Space policies"}],"markDefs":[],"style":"h2"},{"_key":"a77cf4905e83","_type":"block","children":[{"_type":"span","marks":[],"text":"The Archivist or an authorized ACT staff member must attend researchers at all times."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"9a039c533554","_type":"block","children":[{"_type":"span","marks":[],"text":"No pens, markers, or adhesives (e.g. “Post-it” notes) are permitted in the collection space; pencils will be provided upon request."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"beeee9405136","_type":"block","children":[{"_type":"span","marks":[],"text":"Cotton gloves must be worn when handling collection materials; gloves will be provided by the Archivist."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"8b78daa65d60","_type":"block","children":[{"_type":"span","marks":[],"text":"No food or beverages are permitted in the collection space."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"d0188e00a887","_type":"block","children":[{"_type":"span","marks":[],"text":"Laptop use is permitted in the collection space, as well as digital cameras and cellphones. Unless otherwise authorized, any equipment in the collection space (including but not limited to computers, telephones, scanners, and viewing equipment) is for use by ACT staff members only."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"06486dd9e1c6","_type":"block","children":[{"_type":"span","marks":[],"text":"Photocopying machines in the ACT hallway will be accessible by patrons under the supervision of the Archivist."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"e6f6f5255fb6","_type":"block","children":[{"_type":"span","marks":[],"text":"Patrons may only browse materials that have been made available for access."}],"listItem":"bullet","markDefs":[],"style":"normal"},{"_key":"99b3e265fa02","_type":"block","children":[{"_type":"span","marks":[],"text":"Remote access: Reference requests"}],"markDefs":[],"style":"h2"},{"_key":"ea13459d9e46","_type":"block","children":[{"_type":"span","marks":[],"text":"For patrons who are unable to arrange for an on-campus visit to the Archives and Special Collections, reference questions may be directed to the Archivist remotely by email or phone. Generally, emails and phone calls will receive a response within 72 hours of receipt. Requests are typically filled in the order they are received."}],"markDefs":[],"style":"normal"},{"_key":"100958e35c94","_type":"block","children":[{"_type":"span","marks":["strong"],"text":"Use of patron information"}],"markDefs":[],"style":"h2"},{"_key":"2e0dde67b7df","_type":"block","children":[{"_type":"span","marks":[],"text":"Patrons requesting collection materials in person or remotely may be asked to provide certain information to the Archivist, such as contact information and topic(s) of research. This information is only used to track requests for statistical evaluations of collection use and will not be disclosed to outside organizations for any purpose. ACT will endeavor to protect the privacy of all patrons accessing collections."}],"markDefs":[],"style":"normal"},{"_key":"8f39a1ec6366","_type":"block","children":[{"_type":"span","marks":["strong"],"text":"Fees"}],"markDefs":[],"style":"h2"},{"_key":"090062c9e8ce","_type":"block","children":[{"_type":"span","marks":[],"text":"ACT reserves the right to charge an hourly rate for requests that require more than three hours of research on behalf of a patron (remote requests). Collection materials may be scanned and made available upon request, but digitization of certain materials may incur costs. Additionally, requests to publish, exhibit, or otherwise reproduce and display collection materials may incur use fees."}],"markDefs":[],"style":"normal"},{"_key":"e2b58e246069","_type":"block","children":[{"_type":"span","marks":["strong"],"text":"Use of MIT-owned materials by patrons"}],"markDefs":[],"style":"h2"},{"_key":"7cedb6800dc6","_type":"block","children":[{"_type":"span","marks":[],"text":"Permission to examine collection materials in person or remotely (by receiving transfers of digitized materials) does not imply or grant permission to publish or exhibit those materials. Permission to publish, exhibit, or otherwise use collection materials is granted on a case by case basis in accordance with MIT policy, restrictions that may have been placed on materials by donors or depositors, and copyright law. To request permission to publish, exhibit, or otherwise use collection materials, contact the Archivist. "},{"_type":"span","marks":["strong"],"text":"When permission is granted by MIT, patrons must comply with all guidelines provided by ACT for citations, credits, and copyright statements. Exclusive rights to examine or publish material will not be granted."}],"markDefs":[],"style":"normal"}],"output":"<div><h2>In-person access: Research appointments</h2><p>The collection may be examined by arranging a research appointment <strong>in advance</strong> by contacting the ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research appointments at any time. Appointment scheduling is subject to institute holidays and closings. </p><p>The collection space is located at:<br/>20 Ames Street<br/>Building E15-235<br/>Cambridge, Massachusetts 02139</p><h2>In-person access: Space policies</h2><ul><li>The Archivist or an authorized ACT staff member must attend researchers at all times.</li><li>No pens, markers, or adhesives (e.g. “Post-it” notes) are permitted in the collection space; pencils will be provided upon request.</li><li>Cotton gloves must be worn when handling collection materials; gloves will be provided by the Archivist.</li><li>No food or beverages are permitted in the collection space.</li><li>Laptop use is permitted in the collection space, as well as digital cameras and cellphones. Unless otherwise authorized, any equipment in the collection space (including but not limited to computers, telephones, scanners, and viewing equipment) is for use by ACT staff members only.</li><li>Photocopying machines in the ACT hallway will be accessible by patrons under the supervision of the Archivist.</li><li>Patrons may only browse materials that have been made available for access.</li></ul><h2>Remote access: Reference requests</h2><p>For patrons who are unable to arrange for an on-campus visit to the Archives and Special Collections, reference questions may be directed to the Archivist remotely by email or phone. Generally, emails and phone calls will receive a response within 72 hours of receipt. Requests are typically filled in the order they are received.</p><h2><strong>Use of patron information</strong></h2><p>Patrons requesting collection materials in person or remotely may be asked to provide certain information to the Archivist, such as contact information and topic(s) of research. This information is only used to track requests for statistical evaluations of collection use and will not be disclosed to outside organizations for any purpose. ACT will endeavor to protect the privacy of all patrons accessing collections.</p><h2><strong>Fees</strong></h2><p>ACT reserves the right to charge an hourly rate for requests that require more than three hours of research on behalf of a patron (remote requests). Collection materials may be scanned and made available upon request, but digitization of certain materials may incur costs. Additionally, requests to publish, exhibit, or otherwise reproduce and display collection materials may incur use fees.</p><h2><strong>Use of MIT-owned materials by patrons</strong></h2><p>Permission to examine collection materials in person or remotely (by receiving transfers of digitized materials) does not imply or grant permission to publish or exhibit those materials. Permission to publish, exhibit, or otherwise use collection materials is granted on a case by case basis in accordance with MIT policy, restrictions that may have been placed on materials by donors or depositors, and copyright law. To request permission to publish, exhibit, or otherwise use collection materials, contact the Archivist. <strong>When permission is granted by MIT, patrons must comply with all guidelines provided by ACT for citations, credits, and copyright statements. Exclusive rights to examine or publish material will not be granted.</strong></p></div>"}
+{
+  "input": [
+    {
+      "_key": "e3ac53b5b339",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "In-person access: Research appointments"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "a25f0be55c47",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "The collection may be examined by arranging a research appointment "
+        },
+        {
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": "in advance"
+        },
+        {
+          "_type": "span",
+          "marks": [],
+          "text": " by contacting the ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research appointments at any time. Appointment scheduling is subject to institute holidays and closings. "
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "9490a3085498",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "The collection space is located at:\n20 Ames Street\nBuilding E15-235\nCambridge, Massachusetts 02139"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "4c37f3bc1d71",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "In-person access: Space policies"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "a77cf4905e83",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "The Archivist or an authorized ACT staff member must attend researchers at all times."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "9a039c533554",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "No pens, markers, or adhesives (e.g. “Post-it” notes) are permitted in the collection space; pencils will be provided upon request."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "beeee9405136",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Cotton gloves must be worn when handling collection materials; gloves will be provided by the Archivist."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "8b78daa65d60",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "No food or beverages are permitted in the collection space."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "d0188e00a887",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Laptop use is permitted in the collection space, as well as digital cameras and cellphones. Unless otherwise authorized, any equipment in the collection space (including but not limited to computers, telephones, scanners, and viewing equipment) is for use by ACT staff members only."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "06486dd9e1c6",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Photocopying machines in the ACT hallway will be accessible by patrons under the supervision of the Archivist."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "e6f6f5255fb6",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Patrons may only browse materials that have been made available for access."
+        }
+      ],
+      "listItem": "bullet",
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "99b3e265fa02",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Remote access: Reference requests"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "ea13459d9e46",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "For patrons who are unable to arrange for an on-campus visit to the Archives and Special Collections, reference questions may be directed to the Archivist remotely by email or phone. Generally, emails and phone calls will receive a response within 72 hours of receipt. Requests are typically filled in the order they are received."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "100958e35c94",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": "Use of patron information"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "2e0dde67b7df",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Patrons requesting collection materials in person or remotely may be asked to provide certain information to the Archivist, such as contact information and topic(s) of research. This information is only used to track requests for statistical evaluations of collection use and will not be disclosed to outside organizations for any purpose. ACT will endeavor to protect the privacy of all patrons accessing collections."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "8f39a1ec6366",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": "Fees"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "090062c9e8ce",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "ACT reserves the right to charge an hourly rate for requests that require more than three hours of research on behalf of a patron (remote requests). Collection materials may be scanned and made available upon request, but digitization of certain materials may incur costs. Additionally, requests to publish, exhibit, or otherwise reproduce and display collection materials may incur use fees."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "e2b58e246069",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": "Use of MIT-owned materials by patrons"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "7cedb6800dc6",
+      "_type": "block",
+      "children": [
+        {
+          "_type": "span",
+          "marks": [],
+          "text": "Permission to examine collection materials in person or remotely (by receiving transfers of digitized materials) does not imply or grant permission to publish or exhibit those materials. Permission to publish, exhibit, or otherwise use collection materials is granted on a case by case basis in accordance with MIT policy, restrictions that may have been placed on materials by donors or depositors, and copyright law. To request permission to publish, exhibit, or otherwise use collection materials, contact the Archivist. "
+        },
+        {
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": "When permission is granted by MIT, patrons must comply with all guidelines provided by ACT for citations, credits, and copyright statements. Exclusive rights to examine or publish material will not be granted."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    }
+  ],
+  "output": "<div><h2>In-person access: Research appointments</h2><p>The collection may be examined by arranging a research appointment <strong>in advance</strong> by contacting the ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research appointments at any time. Appointment scheduling is subject to institute holidays and closings. </p><p>The collection space is located at:<br/>20 Ames Street<br/>Building E15-235<br/>Cambridge, Massachusetts 02139</p><h2>In-person access: Space policies</h2><ul><li>The Archivist or an authorized ACT staff member must attend researchers at all times.</li><li>No pens, markers, or adhesives (e.g. “Post-it” notes) are permitted in the collection space; pencils will be provided upon request.</li><li>Cotton gloves must be worn when handling collection materials; gloves will be provided by the Archivist.</li><li>No food or beverages are permitted in the collection space.</li><li>Laptop use is permitted in the collection space, as well as digital cameras and cellphones. Unless otherwise authorized, any equipment in the collection space (including but not limited to computers, telephones, scanners, and viewing equipment) is for use by ACT staff members only.</li><li>Photocopying machines in the ACT hallway will be accessible by patrons under the supervision of the Archivist.</li><li>Patrons may only browse materials that have been made available for access.</li></ul><h2>Remote access: Reference requests</h2><p>For patrons who are unable to arrange for an on-campus visit to the Archives and Special Collections, reference questions may be directed to the Archivist remotely by email or phone. Generally, emails and phone calls will receive a response within 72 hours of receipt. Requests are typically filled in the order they are received.</p><h2><strong>Use of patron information</strong></h2><p>Patrons requesting collection materials in person or remotely may be asked to provide certain information to the Archivist, such as contact information and topic(s) of research. This information is only used to track requests for statistical evaluations of collection use and will not be disclosed to outside organizations for any purpose. ACT will endeavor to protect the privacy of all patrons accessing collections.</p><h2><strong>Fees</strong></h2><p>ACT reserves the right to charge an hourly rate for requests that require more than three hours of research on behalf of a patron (remote requests). Collection materials may be scanned and made available upon request, but digitization of certain materials may incur costs. Additionally, requests to publish, exhibit, or otherwise reproduce and display collection materials may incur use fees.</p><h2><strong>Use of MIT-owned materials by patrons</strong></h2><p>Permission to examine collection materials in person or remotely (by receiving transfers of digitized materials) does not imply or grant permission to publish or exhibit those materials. Permission to publish, exhibit, or otherwise use collection materials is granted on a case by case basis in accordance with MIT policy, restrictions that may have been placed on materials by donors or depositors, and copyright law. To request permission to publish, exhibit, or otherwise use collection materials, contact the Archivist. <strong>When permission is granted by MIT, patrons must comply with all guidelines provided by ACT for citations, credits, and copyright statements. Exclusive rights to examine or publish material will not be granted.</strong></p></div>"
+}


### PR DESCRIPTION
This PR adds some logging and fixes test 21. 

I'm not sure about the logging setup - never really set up logging outside a Django project before, but think some debug logging would be useful to maintain - it certainly helped me fix this error 🙂 This might not be the way to set it up though.

## Test resolution

Test 21 highlighted a problem where we did not close off a marker tag correctly.

From these instructions

```
[
  {
    '_type': 'span',
    'marks': [],
    'text': 'The collection may be examined by arranging a research appointment '
  },
  {
    '_type': 'span',
    'marks': [
      'strong'
    ],
    'text': 'in advance'
  },
  {
    '_type': 'span',
    'marks': [],
    'text': ' by contacting the ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research appointments at any time. Appointment scheduling is subject to institute holidays and closings. '
  }
]
```

We were generating 


```html
<p>
        The collection may be examined by arranging a research appointment <strong>in advance by contacting the
        ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests
        may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at 
        least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research
        appointments at any time. Appointment scheduling is subject to institute holidays and closings.
</p>
```

Instead of 

```html
<p>
        The collection may be examined by arranging a research appointment <strong>in advance<strong> by contacting the
        ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests
        may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at 
        least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research
        appointments at any time. Appointment scheduling is subject to institute holidays and closings.
</p>
```

-------------

The problem stemmed from a logical error in the node indexing (pre-looking up prev and next nodes), so we were ending up with `next_node == span`, meaning we expected a strong tag in the next block when there is none. Solved by simplifying the indexing logic a little - though I'm having a hard time understanding how we can make this indexing logic bulletproof. It looks to me like we would have similar issues if we were given two identical texts in a row for instance.