### PR TITLE
Test 26

### DIFF
--- a/sanity_html/renderer.py
+++ b/sanity_html/renderer.py
@@ -16,9 +16,8 @@ if TYPE_CHECKING:
 
 
 class UnhandledNodeError(Exception):
-    """
-    Raised when we receive a node that we cannot parse.
-    """
+    """Raised when we receive a node that we cannot parse."""
+
     pass
 
 
@@ -29,6 +28,7 @@ class MissingSerializerError(UnhandledNodeError):
     This usually means that you need to pass a custom serializer
     to handle the custom type.
     """
+
     pass
 
 
@@ -36,10 +36,10 @@ class SanityBlockRenderer:
     """HTML renderer for Sanity block content."""
 
     def __init__(
-            self,
-            blocks: Union[list[dict], dict],
-            custom_marker_definitions: dict[str, Type[MarkerDefinition]] = None,
-            custom_serializers: dict[str, Callable[[dict, Optional[Block], bool], str]] = None,
+        self,
+        blocks: Union[list[dict], dict],
+        custom_marker_definitions: dict[str, Type[MarkerDefinition]] = None,
+        custom_serializers: dict[str, Callable[[dict, Optional[Block], bool], str]] = None,
     ) -> None:
         logger.debug('Initializing block renderer')
         self._wrapper_element: Optional[str] = None
@@ -112,8 +112,7 @@ class SanityBlockRenderer:
         else:
             if hasattr(node, '_type'):
                 raise MissingSerializerError(
-                    f'Found unhandled node type: {node._type}. '
-                    'Most likely this requires a custom serializer.'
+                    f'Found unhandled node type: {node["_type"]}. ' 'Most likely this requires a custom serializer.'
                 )
             else:
                 raise UnhandledNodeError(f'Received node that we cannot handle: {node.__dict__}')
@@ -219,9 +218,9 @@ class SanityBlockRenderer:
     def _find_list(self, root_node: dict, level: int, list_item: Optional[str] = None) -> Optional[dict]:
         filter_on_type = isinstance(list_item, str)
         if (
-                root_node.get('_type') == 'list'
-                and root_node.get('level') == level
-                and (filter_on_type and root_node.get('listItem') == list_item)
+            root_node.get('_type') == 'list'
+            and root_node.get('level') == level
+            and (filter_on_type and root_node.get('listItem') == list_item)
         ):
             return root_node
 

--- a/tests/fixtures/upstream/026-inline-block-with-text.json
+++ b/tests/fixtures/upstream/026-inline-block-with-text.json
@@ -1,1 +1,24 @@
-{"input":[{"_type":"block","_key":"foo","style":"normal","children":[{"_type":"span","text":"Men, "},{"_type":"button","text":"bli med du også"},{"_type":"span","text":", da!"}]}],"output":"<p>Men, <button>bli med du også</button>, da!</p>"}
+{
+  "input": [
+    {
+      "_type": "block",
+      "_key": "foo",
+      "style": "normal",
+      "children": [
+        {
+          "_type": "span",
+          "text": "Men, "
+        },
+        {
+          "_type": "button",
+          "text": "bli med du også"
+        },
+        {
+          "_type": "span",
+          "text": ", da!"
+        }
+      ]
+    }
+  ],
+  "output": "<p>Men, <button>bli med du også</button>, da!</p>"
+}

--- a/tests/test_upstream_suite.py
+++ b/tests/test_upstream_suite.py
@@ -261,11 +261,16 @@ def test_025_image_with_hotspot():
     assert output == expected_output
 
 
+def button_serializer(node: dict, context: Optional[Block], list_item: bool):
+    return f'<button>{node["text"]}</button>'
+
+
 def test_026_inline_block_with_text():
     fixture_data = get_fixture('fixtures/upstream/026-inline-block-with-text.json')
     input_blocks = fixture_data['input']
     expected_output = fixture_data['output']
-    output = render(input_blocks)
+    sbr = SanityBlockRenderer(input_blocks, custom_serializers={'button': button_serializer})
+    output = sbr.render()
     assert output == expected_output
 
 


### PR DESCRIPTION
This PR fixes test 26 which previously output:

```
E       AssertionError: assert '<p>Men, , da!</p>' == '<p>Men, <but...ton>, da!</p>'
E         - <p>Men, <button>bli med du også</button>, da!</p>
E         + <p>Men, , da!</p>
```

I've made one pretty crucial assumption here - **that button is not covered in the base spec, and should be handled with a custom serializer**. If we wanted to we could instead create a base serializer for button, but button is not mentioned in the block-content-to-hyperscript [serializers](https://github.com/sanity-io/block-content-to-hyperscript/blob/main/src/serializers.js).

Closes #15

## Other changes

There's an unhandled code path in `renderer.py` (that we knew about). The last failing test makes clear that this code path will be hit any time we receive a node with an unknown `_type`. With this in mind it seemed like a nice place to raise some custom errors.